### PR TITLE
Add password hashing and authentication

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -132,6 +132,7 @@ Content-Type: application/json
 {
   "email": "parent@example.com",
   "name": "John Doe",
+  "password": "strongpassword",
   "userType": "parent"
 }
 ```
@@ -142,7 +143,8 @@ POST /api/v1/auth/login
 Content-Type: application/json
 
 {
-  "email": "parent@example.com"
+  "email": "parent@example.com",
+  "password": "strongpassword"
 }
 ```
 

--- a/backend/migrations/0000_initial_schema.sql
+++ b/backend/migrations/0000_initial_schema.sql
@@ -3,6 +3,7 @@ CREATE TABLE users (
     id TEXT PRIMARY KEY,
     email TEXT UNIQUE NOT NULL,
     name TEXT NOT NULL,
+    password_hash TEXT NOT NULL,
     user_type TEXT NOT NULL CHECK (user_type IN ('parent', 'child')),
     parent_id TEXT REFERENCES users(id),
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,8 @@
     "zod": "^3.22.4",
     "jsonwebtoken": "^9.0.2",
     "crypto-js": "^4.2.0",
-    "itty-router": "^4.0.27"
+    "itty-router": "^4.0.27",
+    "bcryptjs": "^2.4.3"
   },
   "devDependencies": {
     "typescript": "^5.3.3",

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -6,6 +6,7 @@ import { AuthMiddleware } from '../middleware/auth';
 import { RateLimitMiddleware } from '../middleware/rateLimit';
 import { CacheService } from '../utils/cache';
 import { Env } from '../types';
+import bcrypt from 'bcryptjs';
 
 export function createAuthRoutes(env: Env) {
   const router = Router();
@@ -53,12 +54,14 @@ export function createAuthRoutes(env: Env) {
         }
       }
 
-      // Create user
+      // Hash password and create user
+      const passwordHash = await bcrypt.hash(validatedData.password, 10);
       const user = await dbService.createUser({
         email: validatedData.email,
         name: validatedData.name,
         userType: validatedData.userType,
-        parentId: validatedData.parentId
+        parentId: validatedData.parentId,
+        passwordHash
       });
 
       // Generate tokens
@@ -110,6 +113,21 @@ export function createAuthRoutes(env: Env) {
         return new Response(JSON.stringify({
           success: false,
           error: 'Invalid email or user not found'
+        }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      // Verify password
+      const isValidPassword = await bcrypt.compare(
+        validatedData.password,
+        user.passwordHash
+      );
+      if (!isValidPassword) {
+        return new Response(JSON.stringify({
+          success: false,
+          error: 'Invalid password'
         }), {
           status: 401,
           headers: { 'Content-Type': 'application/json' }

--- a/backend/src/types/bcryptjs.d.ts
+++ b/backend/src/types/bcryptjs.d.ts
@@ -1,0 +1,1 @@
+declare module 'bcryptjs';

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -4,12 +4,14 @@ import { z } from 'zod';
 export const userRegistrationSchema = z.object({
   email: z.string().email('Invalid email format'),
   name: z.string().min(2, 'Name must be at least 2 characters').max(100, 'Name too long'),
+  password: z.string().min(8, 'Password must be at least 8 characters'),
   userType: z.enum(['parent', 'child'], { required_error: 'User type is required' }),
   parentId: z.string().optional(),
 });
 
 export const userLoginSchema = z.object({
   email: z.string().email('Invalid email format'),
+  password: z.string().min(8, 'Password must be at least 8 characters'),
 });
 
 // Check-in validation schemas


### PR DESCRIPTION
## Summary
- require password in registration and login validation
- persist hashed passwords in the database and verify on login
- document password usage and add bcryptjs dependency

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Argument of type 'RouterType<Route, any[]>' is not assignable to parameter of type 'RouteHandler')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896078d6ef4832484fd1271adfec902