### PR TITLE
feat: rate limit auth by ip

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -266,7 +266,7 @@ Content-Type: application/json
 - **JWT Authentication**: Secure token-based authentication with refresh tokens
 - **AES Encryption**: All sensitive data (notes, messages) are encrypted
 - **Input Validation**: Zod schemas validate all input data
-- **Rate Limiting**: Prevents API abuse with configurable limits
+- **Rate Limiting**: Prevents API abuse with configurable limits (per user or IP)
 - **CORS**: Proper CORS headers for web client support
 
 ## 🚦 Rate Limits
@@ -275,7 +275,8 @@ Content-Type: application/json
 - **Check-ins**: 5 requests per minute
 - **Plan Generation**: 3 requests per 5 minutes
 - **Insights**: 2 requests per 10 minutes
-- **General API**: 30 requests per minute
+- **General API**: 30 requests per minute (per user or IP for unauthenticated requests)
+  - Includes `/auth` endpoints which fall back to IP-based tracking when no user is present
 
 ## 💰 Monetization Strategy
 

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -19,9 +19,12 @@ export function createAuthRoutes(env: Env) {
    */
   router.post('/register', async (request: Request) => {
     try {
-      // Apply rate limiting
-      const mockRequest = { user: { id: 'anonymous' } } as any;
-      await rateLimitMiddleware.applyRateLimit(mockRequest, 'general');
+      // Apply rate limiting using IP address
+      const ip =
+        request.headers.get('cf-connecting-ip') ||
+        request.headers.get('x-forwarded-for')?.split(',')[0] ||
+        '';
+      await rateLimitMiddleware.applyRateLimit(request, 'general', ip);
 
       // Validate request body
       const body = await request.json();
@@ -96,9 +99,12 @@ export function createAuthRoutes(env: Env) {
    */
   router.post('/login', async (request: Request) => {
     try {
-      // Apply rate limiting
-      const mockRequest = { user: { id: 'anonymous' } } as any;
-      await rateLimitMiddleware.applyRateLimit(mockRequest, 'general');
+      // Apply rate limiting using IP address
+      const ip =
+        request.headers.get('cf-connecting-ip') ||
+        request.headers.get('x-forwarded-for')?.split(',')[0] ||
+        '';
+      await rateLimitMiddleware.applyRateLimit(request, 'general', ip);
 
       // Validate request body
       const body = await request.json();
@@ -150,9 +156,12 @@ export function createAuthRoutes(env: Env) {
    */
   router.post('/refresh', async (request: Request) => {
     try {
-      // Apply rate limiting
-      const mockRequest = { user: { id: 'anonymous' } } as any;
-      await rateLimitMiddleware.applyRateLimit(mockRequest, 'general');
+      // Apply rate limiting using IP address
+      const ip =
+        request.headers.get('cf-connecting-ip') ||
+        request.headers.get('x-forwarded-for')?.split(',')[0] ||
+        '';
+      await rateLimitMiddleware.applyRateLimit(request, 'general', ip);
 
       // Get refresh token from body
       const body = await request.json();

--- a/backend/src/utils/cache.ts
+++ b/backend/src/utils/cache.ts
@@ -112,17 +112,19 @@ export class CacheService {
 
   /**
    * Cache rate limit data
+   * @param identifier User ID or IP address
    */
-  async cacheRateLimit(userId: string, endpoint: string, count: number): Promise<void> {
-    const key = this.generateKey('rate_limit', userId, endpoint);
+  async cacheRateLimit(identifier: string, endpoint: string, count: number): Promise<void> {
+    const key = this.generateKey('rate_limit', identifier, endpoint);
     await this.set(key, { count, timestamp: Date.now() }, 60); // 1 minute
   }
 
   /**
    * Get rate limit data
+   * @param identifier User ID or IP address
    */
-  async getRateLimit(userId: string, endpoint: string): Promise<{ count: number; timestamp: number } | null> {
-    const key = this.generateKey('rate_limit', userId, endpoint);
+  async getRateLimit(identifier: string, endpoint: string): Promise<{ count: number; timestamp: number } | null> {
+    const key = this.generateKey('rate_limit', identifier, endpoint);
     return this.get(key);
   }
 


### PR DESCRIPTION
## Summary
- extract requester IP from headers in `/auth` endpoints
- extend rate limiter to use user id or IP identifier
- document IP-based auth rate limiting

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689607941ae8832480cf285c1c6874cd